### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ language: php
 php:
 - '7.1'
 - '7.2'
+- '7.3'
 install:
 - composer install --prefer-dist

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,10 @@
             "email": "joseph@sehrgute.software"
         }
     ],
-    "require": {},
+    "require": {
+        "php": "^7.1",
+        "ext-mbstring": "*"
+    },
     "require-dev": {
         "phpunit/phpunit": "~7.0"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,12 @@
          beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutTodoAnnotatedTests="true"
          verbose="true">
-    <testsuite>
+    <testsuite name="MbStrPad test">
         <directory suffix="Test.php">tests</directory>
     </testsuite>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/tests/MbStrPadTest.php
+++ b/tests/MbStrPadTest.php
@@ -55,6 +55,13 @@ class MbStrPadTest extends TestCase
     public function test_throws_an_exception_if_pad_type_is_invalid()
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid value for argument $pad_type');
+
         mb_str_pad('padmenot', 10, ' ', 100);
+    }
+
+    public function test_input_string_is_bail_early()
+    {
+        $this->assertEquals('bail_early', mb_str_pad('bail_early', 10));
     }
 }


### PR DESCRIPTION
# Changed log
- Add `php-7.3` test on Travis CI build.
- Add the `"php": "^7.1"` and `"ext-mbstring": "*"` inside `require` block in `composer.json`.
- Add the test suite name in `phpunit.xml.dist` setting file.
- Add the missed test.
- Add the `expectExceptionMessage` to check whether expected exception message is same as result.